### PR TITLE
Use a default xorg.conf if one exists

### DIFF
--- a/dc-burn-netbsd
+++ b/dc-burn-netbsd
@@ -123,6 +123,12 @@ run_rc_command "$1"
     chmod 755 $data_dir/etc/rc.d/readonlyroot
 fi
 
+# Provide xinit with a usable default xorg.conf
+if [ -f $data_dir/etc/X11/xorg.conf.uskbd ] ; then
+    echo "Create xorg.conf"
+    cp $data_dir/etc/X11/xorg.conf.uskbd $data_dir/etc/X11/xorg.conf
+fi
+
 if grep -q 'rc_configured=NO' $data_dir/etc/rc.conf ; then
     echo "Update rc.conf"
     (


### PR DESCRIPTION
X's configure command doesn't seem to work correctly, or at least the netbsd_7 branch of xsrc from today: 

``` bash
$ X -configure
... snip ...
No devices to configure. Configuration falied.
```

So if xorg.conf.uskbd exists, this script uses that as the default which it will at least allow xinit to run.
